### PR TITLE
Added value checking & recursion to num_children_with_feature

### DIFF
--- a/lib/treat/entities/abilities/iterable.rb
+++ b/lib/treat/entities/abilities/iterable.rb
@@ -95,11 +95,13 @@ module Treat::Entities::Abilities::Iterable
   
   # Number of children that have a given feature.
   # Second variable to allow for passing value to check for.
-  def num_children_with_feature(feature, value = nil, recursive = false)
+  def num_children_with_feature(feature, recursive = false, value = nil)
     i = 0
       each do |c|
         # If Recursive ...
-        i += num_children_with_feature(feature, value, true) if recursive == true && c.has_children?
+        if recursive == true && c.has_children?
+          i += c.num_children_with_feature(feature, true, value)
+        end
         if value == nil
           i += 1 if c.has?(feature)
         else


### PR DESCRIPTION
New def => def num_children_with_feature(feature, recursive = false, value = nil)

1.9.3p194 :011 > p.num_children_with_feature(:tag)
 => 0 # No recursion
1.9.3p194 :012 > p.num_children_with_feature(:tag,true)
 => 50 # Recursion
1.9.3p194 :013 > p.num_children_with_feature(:tag,true,"NP")
 => 10 # Recursion & value checking.

Didn't change the order for feature & defaulted recursion to false so old code running it will still work in the same way.
