### PR TITLE
Fix method contract bug in detect_format

### DIFF
--- a/lib/treat/workers/formatters/readers/autoselect.rb
+++ b/lib/treat/workers/formatters/readers/autoselect.rb
@@ -17,10 +17,10 @@ class Treat::Workers::Formatters::Readers::Autoselect
     const_get(fmt.cc).read(document,options)
   end
   
-  def self.detect_format(filename, default_to = nil)
+  def self.detect_format(file, default_to = nil)
     
     default_to ||= DefaultOptions[:default_to]
-    ext = filename.scan(ExtensionRegexp)
+    ext = file.path.scan(ExtensionRegexp)
     ext = (ext.is_a?(Array) && ext[0] && ext[0][0]) ? ext[0][0] : ''
     
     format = ImageExtensions.include?(ext) ? 'image' : ext


### PR DESCRIPTION
Calls to detect_format() passed a file, but the method expected a filename.

```
/Users/turadg/Code/Ruby/treat/lib/treat/entities/entity/buildable.rb:
  214      else
  215        fmt = Treat::Workers::Formatters::
  216:       Readers::Autoselect.detect_format(file,def_fmt)
  217        from_raw_file(file, fmt)
  218      end

/Users/turadg/Code/Ruby/treat/lib/treat/workers/formatters/readers/autoselect.rb:
   13    def self.read(document, options = {})
   14      options = DefaultOptions.merge(options)
   15:     fmt = detect_format(document.file, options[:default_to])
   16      Treat::Workers::Formatters::Readers.
   17      const_get(fmt.cc).read(document,options)
   18    end
   19    
   20:   def self.detect_format(filename, default_to = nil)
   21      
   22      default_to ||= DefaultOptions[:default_to]


3 matches across 2 files
```

This patch changes the parameter to a file as expected.
