### PR TITLE
Little patch to german.rb to fix issue #39

### DIFF
--- a/lib/treat/config/data/languages/german.rb
+++ b/lib/treat/config/data/languages/german.rb
@@ -1,3 +1,5 @@
+#encoding: UTF-8
+
 {
   dependencies: [
     'punkt-segmenter', 


### PR DESCRIPTION
It fixes issue #39 — https://github.com/louismullie/treat/issues/39 with invalid multibyte char (US-ASCII)
