### PR TITLE
added "encoding: utf-8" to german.rb

### DIFF
--- a/lib/treat/config/data/languages/german.rb
+++ b/lib/treat/config/data/languages/german.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 {
   dependencies: [
     'punkt-segmenter', 


### PR DESCRIPTION
to fix error:

SyntaxError: (eval):60: invalid multibyte char (US-ASCII)
(eval):60: invalid multibyte char (US-ASCII)
(eval):60: syntax error, unexpected $end, expecting ']'
      "für",
          ^
