### PR TITLE
Update Ocropus calls to work with v 0.7

### DIFF
--- a/lib/treat/workers/formatters/readers/image.rb
+++ b/lib/treat/workers/formatters/readers/image.rb
@@ -21,11 +21,6 @@ class Treat::Workers::Formatters::Readers::Image
 
     read = lambda do |doc|
       self.create_temp_dir do |tmp|
-        # `ocropus book2pages #{tmp}/out #{doc.file}`
-        # `ocropus pages2lines #{tmp}/out`
-        # `ocropus lines2fsts #{tmp}/out`
-        # `ocropus buildhtml #{tmp}/out > #{tmp}/output.html`
-
         `ocropus-nlbin -o #{tmp}/out #{doc.file}`
         `ocropus-gpageseg #{tmp}/out/????.bin.png --minscale 2`
         `ocropus-rpred #{tmp}/out/????/??????.bin.png`
@@ -37,15 +32,13 @@ class Treat::Workers::Formatters::Readers::Image
       end
     end
 
-
     Treat.core.verbosity.silence ? silence_stdout {
     read.call(document) } : read.call(document)
 
     document
-
   end
 
-  # Create a dire that gets deleted after execution of the block.
+  # Create a dir that gets deleted after execution of the block.
   def self.create_temp_dir(&block)
     if not FileTest.directory?(Treat.paths.tmp)
       FileUtils.mkdir(Treat.paths.tmp)


### PR DESCRIPTION
I noticed the Ocropus functions the gem uses are no longer supported in the latest version. I basically just copied the four commands from the [FAQ](https://code.google.com/p/ocropus/wiki/FrequentlyAskedQuestions), although I added the `--minscale 2` flag since I think it should at least try to recognize low resolution images. Maybe this  could be part of the options hash though?

It works just fine as part of a script, but for some reason when I try to create a document object with an image file in IRB it hangs after returning the new object. I'm pretty sure its some problem with the image worker, but I haven't figured out what yet.

edit: looks like the IRB problem is with the `silence_stdout` method; when it runs the prompt isn't restored and you can't see keystrokes.
