### PR TITLE
Add dependencies required in order to successfully require treat

### DIFF
--- a/treat.gemspec
+++ b/treat.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'birch'
   s.add_runtime_dependency 'yomu'
   
+  s.add_runtime_dependency 'open-nlp'
+  s.add_runtime_dependency 'stanford-core-nlp'
   # Development dependencies
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Installation instructions tell the user to type `require 'treat'` after
installation, but on a clean system without the `open-nlp` and
`stanford-core-nlp` gems installed, this require statement fails. These
two gems should be included in the gem dependencies.
