### PR TITLE
Fix Rubygems source in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
The use of source :rubygems has been deprecated, and causes the system
to issue a warning when bundle is used with the gem. This change removes the deprecation warning and ensures that the request to Rubygems is made over HTTPS.
