### PR TITLE
Allow Treat::Core::Installer.install to accept schiphol download options, eg. suppress progress bar for some terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+**Fork Changes**
+Allow Treat::Core::Installer.install to accept schiphol download options, eg. suppress progress bar for some terminals
+
 [![Build Status](https://secure.travis-ci.org/louismullie/treat.png)](http://travis-ci.org/#!/louismullie/treat)
 [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/louismullie/treat)
 

--- a/lib/treat/core/installer.rb
+++ b/lib/treat/core/installer.rb
@@ -23,7 +23,7 @@ module Treat::Core::Installer
   
   # Install required dependencies and optional
   # dependencies for a specific language.
-  def self.install(language = 'english')
+  def self.install(language = 'english', download_options = {})
     
     # Require the Rubygem dependency installer.
     silence_warnings do
@@ -52,7 +52,7 @@ module Treat::Core::Installer
       begin
         Gem::Specification.find_by_name('punkt-segmenter')
         title "Downloading models for the Punkt segmenter for the #{l}."
-        download_punkt_models(language)
+        download_punkt_models(language, download_options)
       rescue Gem::LoadError; end
 
       # If stanford is installed, download models.
@@ -61,7 +61,7 @@ module Treat::Core::Installer
         title "Download Stanford Core NLP JARs and " +
         "model files for the the #{l}.\n\n"
         package = (language == :english) ? :english : :all
-        download_stanford(package)
+        download_stanford(package, download_options)
       rescue Gem::LoadError; end
 
     rescue Errno::EACCES => e
@@ -91,13 +91,12 @@ module Treat::Core::Installer
     end
   end
 
-  def self.download_stanford(package = :minimal)
+  def self.download_stanford(package = :minimal, options = {})
     
     f = StanfordPackages[package]
     url = "http://#{Server}/treat/#{f}"
-    loc = Schiphol.download(url, 
-      download_folder: Treat.paths.tmp
-    )
+    options.merge(download_folder: Treat.paths.tmp)
+    loc = Schiphol.download(url, options)
     puts "- Unzipping package ..."
     dest = File.join(Treat.paths.tmp, 'stanford')
     unzip_stanford(loc, dest)
@@ -141,14 +140,13 @@ module Treat::Core::Installer
     
   end
 
-  def self.download_punkt_models(language)
+  def self.download_punkt_models(language, options = {})
 
     f = "#{language}.yaml"
     dest = "#{Treat.paths.models}punkt/"
     url = "http://#{Server}/treat/punkt/#{f}"
-    loc = Schiphol.download(url, 
-      download_folder: Treat.paths.tmp
-    )
+    options.merge(download_folder: Treat.paths.tmp)
+    loc = Schiphol.download(url, options)
     unless File.readable?(dest)
       puts "- Creating directory models/punkt ..."
       FileUtils.mkdir_p(File.absolute_path(dest))


### PR DESCRIPTION
I was not able to run the installer on my Chef-based AWS Opsworks -based Rails application deploy, it would fail with 
    tput: unknown terminal "unknown"

Suppressing the progress bar fixed this, so I changed the install method signature to allow passing in options to the downloader.

Sorry this is my first pull request: not sure how to exclude my README.md file changes without rebranching or something.
