### PR TITLE
Revert "Considerably simplify all time annotators."

### DIFF
--- a/lib/treat/workers/extractors/time/chronic.rb
+++ b/lib/treat/workers/extractors/time/chronic.rb
@@ -2,17 +2,52 @@
 # Ruby natural language date parser.
 class Treat::Workers::Extractors::Time::Chronic
 
-  require 'chronic'
+  # Require the 'chronic' gem.
+  silence_warnings { require 'chronic' }
+
+  # Require the Ruby DateTime module
   require 'date'
-  
-  DefaultOptions = {guess: true}
 
   # Return the date information contained within 
   # the entity by parsing it with the 'chronic' gem.
+  #
+  # Options: none.
   def self.time(entity, options = {})
-    options = DefaultOptions.merge(options)
-    time = ::Chronic.parse(entity.to_s, options)
-    time ? DateTime.parse(time.to_s) : nil
+
+    s = entity.to_s
+    return if s =~ /^[0-9]+$/
+    time = nil
+    
+    silence_warnings do
+      time = ::Chronic.parse(s, {:guess => true})
+    end
+    
+    if entity.has_parent? && remove_time_from_ancestors(entity, time)
+      nil
+    else
+      time
+    end
+    
+  end
+  
+  # Keeps the lowest-level time annotations that do
+  # not conflict with a higher time annotation.
+  # Returns true if the entity conflicts with a
+  # higher-level time annotation.
+  def self.remove_time_from_ancestors(entity, time)
+    
+    entity.ancestors_with_type(:phrase).each do |a|
+      
+      next if !a.has?(:time)
+      unless a.get(:time) == time
+        return true
+      end
+      a.unset(:time)
+      
+    end
+    
+    false
+    
   end
 
 end

--- a/lib/treat/workers/extractors/time/nickel.rb
+++ b/lib/treat/workers/extractors/time/nickel.rb
@@ -47,6 +47,7 @@ class Treat::Workers::Extractors::Time::Nickel
     occ.interval : :none
     time_recurrence_interval = interval
 
+
     s = [occ.start_date, occ.start_time]
     ds = [s[0].year, s[0].month, s[0].day] if s[0]
     ts = [s[1].hour, s[1].minute, s[1].second] if s[1]
@@ -74,6 +75,20 @@ class Treat::Workers::Extractors::Time::Nickel
       start_time
     end
     
+  end
+
+  # Keeps the lowest-level time annotations that do
+  # not conflict with a higher time annotation.
+  # Returns true if the entity conflicts with a
+  # higher-level time annotation.
+  def self.remove_time_from_ancestors(entity, time)
+    entity.ancestors_with_type(:phrase).each do |a|
+      next if !a.has?(:time)
+      return false unless a.get(:time).to_s == time.to_s
+      a.unset(:time, :time_recurrence, 
+      :time_recurrence_interval, :end_time)
+    end
+    true
   end
 
 end

--- a/lib/treat/workers/extractors/time/ruby.rb
+++ b/lib/treat/workers/extractors/time/ruby.rb
@@ -2,7 +2,7 @@
 # DateTime.parse() method.
 class Treat::Workers::Extractors::Time::Ruby
 
-
+  # Require Ruby's date module.
   require 'date'
 
   # Return a DateTime object representing the date/time
@@ -13,11 +13,42 @@ class Treat::Workers::Extractors::Time::Ruby
   #
   # Options: none.
   def self.time(entity, options = {})
+    s = entity.to_s
+    return if s =~ /^[0-9]+$/
     begin
-      DateTime.parse(entity.to_s)
+      time = ::DateTime.parse(s)
+      if  entity.has_parent? && 
+        remove_time_from_ancestors(entity, time)
+        nil
+      else
+        time
+      end
     rescue
       nil
     end
   end
 
+  
+  # Keeps the lowest-level time annotations that do
+  # not conflict with a higher time annotation.
+  # Returns true if the entity conflicts with a
+  # higher-level time annotation.
+  def self.remove_time_from_ancestors(entity, time)
+    
+    entity.ancestors_with_type(:phrase).each do |a|
+      
+      next if !a.has?(:time)
+
+      unless a.get(:time) == time
+        return true
+      end
+      
+      a.unset(:time)
+      
+    end
+    
+    false
+    
+  end
+  
 end


### PR DESCRIPTION
This reverts commit 01c3e50ef08b5064dd3033520e21f885bf58ae58.
