### PR TITLE
rspec file fix

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format s -c
+--format d -c
 --order rand


### PR DESCRIPTION
The .rspec file was trying to use a formatter that rspec does not recognize.  TravisCI builds were failing as a result.
