### PR TITLE
Put quotes around gem name in post-install message.

### DIFF
--- a/treat.gemspec
+++ b/treat.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   
   # Post-install message
   s.post_install_message = %q{Thanks for installing Treat.
-  To complete the installation, run `require treat` in an IRB 
+  To complete the installation, run `require 'treat'` in an IRB 
   terminal, followed by `Treat::Core::Installer.install`. }
 
 end


### PR DESCRIPTION
The post-install message for this gem instructs the user to run `require
treat` from irb, however, the actual, functioning line of code involves
quotes, namely, `require 'treat'`.