### PR TITLE
fixes errors caused by wordnet 1.0.0

### DIFF
--- a/lib/treat/workers/lexicalizers/sensers/wordnet.rb
+++ b/lib/treat/workers/lexicalizers/sensers/wordnet.rb
@@ -1,35 +1,35 @@
 # Sense information (synonyms, antonyms, hypernyms
 # and hyponyms) obtained through a Ruby parser that
 # accesses Wordnet flat files.
-# 
-# Original paper: George A. Miller (1995). WordNet: 
-# A Lexical Database for English. Communications of 
+#
+# Original paper: George A. Miller (1995). WordNet:
+# A Lexical Database for English. Communications of
 # the ACM Vol. 38, No. 11: 39-41.
 class Treat::Workers::Lexicalizers::Sensers::Wordnet
 
   # Require the 'wordnet' gem (install as 'rwordnet').
   require 'wordnet'
-  
+
   # Patch for bug.
   ::WordNet.module_eval do
-    remove_const(:SynsetType)
-    const_set(:SynsetType, 
+    remove_const(:SYNSET_TYPES)
+    const_set(:SYNSET_TYPES,
     {"n" => "noun", "v" => "verb", "a" => "adj"})
   end
-  
+
   # Require an adaptor for Wordnet synsets.
   require_relative 'wordnet/synset'
-  
+
   # Noun, adjective and verb indexes.
   @@indexes = {}
-  
+
   # Obtain lexical information about a word using the
   # ruby 'wordnet' gem.
   def self.sense(word, options = nil)
-    
+
     category = word.check_has(:category)
-    
-    if !options[:nym] 
+
+    if !options[:nym]
       raise Treat::Exception, "You must supply " +
       "the :nym option ('synonyms', 'hypernyms', etc.)"
     end
@@ -37,32 +37,30 @@ class Treat::Workers::Lexicalizers::Sensers::Wordnet
     if !options[:nym].is_a?(Symbol)
       options[:nym] = options[:nym].intern
     end
-  
+
     if ![:synonyms, :antonyms,
       :hypernyms, :hyponyms].include?(options[:nym])
       raise Treat::Exception, "You must supply " +
-      "a valid :nym option ('synonyms', 'hypernyms', etc.)" 
+      "a valid :nym option ('synonyms', 'hypernyms', etc.)"
     end
-    
+
     unless ['noun', 'adjective', 'verb'].
       include?(word.category)
       return []
     end
-    
+
     cat = category.to_s.capitalize
-    
-    @@indexes[cat] ||= 
-    ::WordNet.const_get(cat + 'Index').instance
-    lemma = @@indexes[cat].find(word.value.downcase)
+
+    lemma = ::WordNet::Lemma.find(word.value.downcase, cat.to_sym)
 
     return [] if lemma.nil?
     synsets = []
-    
+
     lemma.synsets.each do |synset|
-      synsets << 
+      synsets <<
       Treat::Workers::Lexicalizers::Sensers::Wordnet::Synset.new(synset)
     end
-    
+
     ((synsets.collect do |ss|
       ss.send(options[:nym])
     end - [word.value]).


### PR DESCRIPTION
This is a fix for issue #97. wordnet 1.0.0 has some minor refactorings which breaks methods such as synonyms and hypnonyms. 
