### PR TITLE
abbreviates adjective and adverb to work properly with rwordnet

### DIFF
--- a/lib/treat/version.rb
+++ b/lib/treat/version.rb
@@ -1,8 +1,8 @@
 module Treat
-  
+
   # The current version of Treat.
   VERSION = '2.1.0'
-  
+
   # Treat requires Ruby >= 1.9.2
   if RUBY_VERSION < '1.9.2'
     raise "Treat requires Ruby version 1.9.2 " +

--- a/lib/treat/workers/lexicalizers/sensers/wordnet.rb
+++ b/lib/treat/workers/lexicalizers/sensers/wordnet.rb
@@ -20,9 +20,6 @@ class Treat::Workers::Lexicalizers::Sensers::Wordnet
   # Require an adaptor for Wordnet synsets.
   require_relative 'wordnet/synset'
 
-  # Noun, adjective and verb indexes.
-  @@indexes = {}
-
   # Obtain lexical information about a word using the
   # ruby 'wordnet' gem.
   def self.sense(word, options = nil)
@@ -49,9 +46,9 @@ class Treat::Workers::Lexicalizers::Sensers::Wordnet
       return []
     end
 
-    cat = category.to_s.capitalize
+    cat = abbreviate(category)
 
-    lemma = ::WordNet::Lemma.find(word.value.downcase, cat.to_sym)
+    lemma = ::WordNet::Lemma.find(word.value.downcase, cat)
 
     return [] if lemma.nil?
     synsets = []
@@ -66,6 +63,16 @@ class Treat::Workers::Lexicalizers::Sensers::Wordnet
     end - [word.value]).
     flatten).uniq.map do |token|
       token.gsub('_', ' ')
+    end
+  end
+
+  def self.abbreviate category
+    if category == 'adjective'
+      :adj
+    elsif category == 'adverb'
+      :adv
+    else
+      category.to_sym
     end
   end
 


### PR DESCRIPTION
My last pull request caused some errors to be thrown when using methods involving synsets were called on adverbs or adjectives. Apparently rwordnet now needs to receive abbreviations of these pos in order to use synsets properly. 