### PR TITLE
Update .travis.yml for Ruby 2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: ruby
+
 rvm:
   - 1.9.2
   - 1.9.3
+  - 2.0
+  - 2.1
+  - 2.2
+
 before_install:
   - export "JAVA_HOME=/usr/lib/jvm/java-6-openjdk-i386/"
-before_script: 
+
+before_script:
   - sudo apt-get install antiword
   - sudo apt-get install poppler-utils
   - rake treat:install[travis] --trace
+
 script: rake treat:spec --trace


### PR DESCRIPTION
This PR adds Ruby 2.0, 2.1 and 2.2 to the Travis CI build matrix.