### PR TITLE
Fixed typo in phrase tag that causes Adverbial Phrases to parse improperly

### DIFF
--- a/lib/treat/config/data/tags.rb
+++ b/lib/treat/config/data/tags.rb
@@ -26,7 +26,7 @@
       'Verb phrase', ['', '', 'VP', '', '', ''],
       'Inverted yes/no question', ['', '', 'SQ', '', '', ''],
       'Wh adjective phrase', ['', '', 'WHADJP', '', '', ''],
-      'Wh adverb phrase', ['', '', 'WHAVP', '', '', ''],
+      'Wh adverb phrase', ['', '', 'WHADVP', '', '', ''],
       'Wh noun phrase', ['', '', 'WHNP', '', '', ''],
       'Wh prepositional phrase', ['', '', 'WHPP', '', '', ''],
       'Unknown', ['', '', 'X', '', '', ''],


### PR DESCRIPTION
Looks like there's a typo on one of the phrase tags that will cause any Adverbial Phrases to parse improperly:

```ruby
# lib/treat/config/data/tags.rb:29
'Wh adverb phrase', ['', '', 'WHAVP', '', '', ''],
```

`WHAVP` is actually called `WHADVP` in the Stanford parser.

This patch fixes #103, where `to_s` will cause some phrases to parse with extra tagging information (parentheses) in them.

**Before patch:**
```
> Treat::Entities::Sentence.new("How is it done?").apply(:tokenize, :parse).to_s
=> "(WRB How) is it done?"
```
**After patch:**
```
> Treat::Entities::Sentence.new("How is it done?").apply(:tokenize, :parse).to_s
=> "How is it done?"
```