### PR TITLE
Change server for hosted files to aws mirror

### DIFF
--- a/lib/treat/core/installer.rb
+++ b/lib/treat/core/installer.rb
@@ -5,7 +5,7 @@ module Treat::Core::Installer
   require 'schiphol'
 
   # Address of the server with the files.
-  Server = 'www.louismullie.com'
+  Server = 's3.amazonaws.com/static-public-assets'
 
   # Filenames for the Stanford packages.
   StanfordPackages = {


### PR DESCRIPTION
The current server the installer tries to connect to is offline. Until that website is back online I propose changing the server specified in `installer.rb` to the AWS mirror so that users can use the installer.